### PR TITLE
add deprecatiion warning to relevancy_index

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -4,5 +4,9 @@ Pending Release Notes
 Updates / New Features
 ----------------------
 
+Interfaces
+
+* Deprecated the RelevancyIndex interface in favor of RankRelevancy
+
 Fixes
 -----

--- a/smqtk_relevancy/interfaces/relevancy_index.py
+++ b/smqtk_relevancy/interfaces/relevancy_index.py
@@ -1,8 +1,13 @@
 import abc
 from typing import Iterable, Dict
+from warnings import warn
 
 from smqtk_core import Plugfigurable
 from smqtk_descriptors import DescriptorElement
+
+
+warn("Relevancy Index is deprecated and may be removed in a future release."
+     "Please use Rank Relevancy instead.")
 
 
 class NoIndexError (Exception):


### PR DESCRIPTION
Purpose of this PR is to add a deprecation warning to the RelevancyIndex interface in favor of RankRelevancy